### PR TITLE
chore: Update artifact registry gradle plugin to recommended version

### DIFF
--- a/java/consumer/build.gradle
+++ b/java/consumer/build.gradle
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 plugins {
-    id "com.google.cloud.artifactregistry.gradle-plugin" version "2.1.1"
+    id "com.google.cloud.artifactregistry.gradle-plugin" version "2.1.5"
 }
 
 repositories {

--- a/java/driver/build.gradle
+++ b/java/driver/build.gradle
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 plugins {
-    id "com.google.cloud.artifactregistry.gradle-plugin" version "2.1.1"
+    id "com.google.cloud.artifactregistry.gradle-plugin" version "2.1.5"
 }
 
 repositories {


### PR DESCRIPTION
chore: Update artifact registry gradle plugin to recommended version

2.1.5 is the current recommended version for com.google.cloud.artifactregistry.gradle-plugin