### PR TITLE
fix: Update location intervals to 5 seconds minimum

### DIFF
--- a/java/driver/src/main/java/com/google/mapsplatform/transportation/sample/driver/VehicleController.java
+++ b/java/driver/src/main/java/com/google/mapsplatform/transportation/sample/driver/VehicleController.java
@@ -65,7 +65,7 @@ public class VehicleController implements VehicleStateService.VehicleStateListen
   private static final float SIMULATOR_SPEED_MULTIPLIER = 5.0f;
 
   // Faster location update interval during journey sharing.
-  private static final long JOURNEY_SHARING_LOCATION_UPDATE_INTERVAL_SECONDS = 1;
+  private static final long JOURNEY_SHARING_LOCATION_UPDATE_INTERVAL_SECONDS = 5;
 
   // Pattern of a FleetEngine full qualified a vehicle name.
   private static final Pattern VEHICLE_NAME_FORMAT =

--- a/kotlin/kotlin-driver/src/main/kotlin/com/google/mapsplatform/transportation/sample/kotlindriver/VehicleController.kt
+++ b/kotlin/kotlin-driver/src/main/kotlin/com/google/mapsplatform/transportation/sample/kotlindriver/VehicleController.kt
@@ -422,7 +422,7 @@ class VehicleController(
     private const val SIMULATOR_SPEED_MULTIPLIER = 5.0f
 
     // Faster location update interval during journey sharing.
-    private const val JOURNEY_SHARING_LOCATION_UPDATE_INTERVAL_SECONDS: Long = 1
+    private const val JOURNEY_SHARING_LOCATION_UPDATE_INTERVAL_SECONDS: Long = 5
 
     // Pattern of a FleetEngine full qualified a vehicle name.
     private val VEHICLE_NAME_FORMAT = Pattern.compile("providers/(.*)/vehicles/(.*)")


### PR DESCRIPTION
fix: Update location intervals to 5 seconds minimum

The SDK is being updated to support 5 seconds as the minimum reporting interval. This updates the Driver sample apps to prepare for that.