### PR TITLE
fix: include cronet-fallback to address crash due to missing class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@
  */
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 project.ext {
-    consumerSdkVersion = "2.0.0"
+    consumerSdkVersion = "2.1.0"
     driverSdkVersion = "5.0.0"
     autoValueVersion = "1.8.2"
     appCompatVersion = "1.4.0"
@@ -47,6 +47,7 @@ project.ext {
     ktCouroutinesVersion = "1.6.0"
     lifecycleVersion = "2.4.0"
     desugarJdkLibsVersion = "2.0.3"
+    cronetFallbackVersion = "119.6045.31"
 }
 
 buildscript {

--- a/java/driver/build.gradle
+++ b/java/driver/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     implementation "com.squareup.retrofit2:adapter-guava:$retrofit2Version"
     implementation "org.checkerframework:checker-qual:$checkerVersion"
     implementation "com.google.android.libraries.mapsplatform.transportation:transportation-driver:$driverSdkVersion"
+    implementation "org.chromium.net:cronet-fallback:$cronetFallbackVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$anroidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"

--- a/kotlin/kotlin-driver/build.gradle
+++ b/kotlin/kotlin-driver/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation "com.google.android.libraries.mapsplatform.transportation:transportation-driver:$driverSdkVersion"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$ktCouroutinesVersion"
+    implementation "org.chromium.net:cronet-fallback:$cronetFallbackVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVersion"


### PR DESCRIPTION
fix: include cronet-fallback to address crash due to missing class

Adds a workaround to prevent app from crashing when building NavSDK 5.2.0

- Also bumping ConsumerSDK to the latest public release.