### PR TITLE
fix: Disable the action button when the camera is moving.

### DIFF
--- a/java/consumer/src/main/java/com/google/mapsplatform/transportation/sample/consumer/SampleAppActivity.java
+++ b/java/consumer/src/main/java/com/google/mapsplatform/transportation/sample/consumer/SampleAppActivity.java
@@ -251,18 +251,33 @@ public class SampleAppActivity extends AppCompatActivity
                 return;
               }
 
-              @AppStates int state = consumerViewModel.getAppState().getValue();
-              if (state != AppStates.SELECTING_DROPOFF && state != AppStates.SELECTING_PICKUP) {
-                return;
-              }
-
               LatLng cameraLocation = cameraPosition.target;
               TerminalLocation terminalLocation = TerminalLocation.create(cameraLocation);
 
               consumerViewModel.updateLocationPointForState(cameraLocation);
               updateMarkerBasedOnState(terminalLocation);
+
+              // *** Enable the action button when the camera is idle ***
+              actionButton.setEnabled(true);
+              updateActionButtonAppearance();
+            });
+
+    // *** Disable the action button when the camera starts moving ***
+    requireNonNull(googleMap)
+            .setOnCameraMoveStartedListener(reason -> {
+              actionButton.setEnabled(false);
+              updateActionButtonAppearance();
             });
   }
+
+  private void updateActionButtonAppearance() {
+    // *** Use ternary operator to simplify color selection ***
+    int backgroundColorResource = actionButton.isEnabled() ? R.color.actionable : R.color.disabled;
+
+    Drawable roundedButton = actionButton.getBackground();
+    DrawableCompat.setTint(roundedButton, ContextCompat.getColor(this, backgroundColorResource));
+  }
+
 
   /**
    * Updates the current marker (depending on app state) to the given location. Ex: when app state

--- a/kotlin/kotlin-consumer/src/main/kotlin/com/google/mapsplatform/transportation/sample/kotlinconsumer/SampleAppActivity.kt
+++ b/kotlin/kotlin-consumer/src/main/kotlin/com/google/mapsplatform/transportation/sample/kotlinconsumer/SampleAppActivity.kt
@@ -243,20 +243,22 @@ class SampleAppActivity : AppCompatActivity(), ConsumerViewModel.JourneySharingL
     googleMap?.setOnCameraIdleListener(
       GoogleMap.OnCameraIdleListener {
         val cameraPosition = googleMap?.cameraPosition ?: return@OnCameraIdleListener
-
-        if (
-          consumerViewModel.appState != AppStates.SELECTING_DROPOFF &&
-            consumerViewModel.appState != AppStates.SELECTING_PICKUP
-        ) {
-          return@OnCameraIdleListener
-        }
-
         val cameraLocation = cameraPosition.target
         val terminalLocation = TerminalLocation.create(cameraLocation)
         consumerViewModel.updateLocationPointForState(cameraLocation)
         updateMarkerBasedOnState(terminalLocation)
+
+        // Re-enable the button after camera is idle
+        actionButton.isEnabled = true
+        updateActionButtonAppearance()
       }
     )
+
+    // Disable the action button when the camera starts moving.
+    googleMap?.setOnCameraMoveStartedListener {
+      actionButton.isEnabled = false
+      updateActionButtonAppearance()
+    }
   }
 
   /**
@@ -579,6 +581,14 @@ class SampleAppActivity : AppCompatActivity(), ConsumerViewModel.JourneySharingL
     if (consumerViewModel.appState == AppStates.JOURNEY_SHARING) {
       drawJourneySharingStateMarkers(waypoints)
     }
+  }
+
+  private fun updateActionButtonAppearance() {
+    val backgroundColor = if (actionButton.isEnabled) R.color.actionable else R.color.disabled
+    DrawableCompat.setTint(
+      actionButton.background,
+      ContextCompat.getColor(this, backgroundColor)
+    )
   }
 
   /** Renders a polyline representing all the points contained for the given trip. */


### PR DESCRIPTION
This prevents the user from accidentally creating a trip while the location latLng is not yet defined.

Also, update the action button appearance when it is enabled disabled.
